### PR TITLE
Fix instance language selection in title count query

### DIFF
--- a/sql/derived_tables/instance_languages.sql
+++ b/sql/derived_tables/instance_languages.sql
@@ -1,14 +1,15 @@
 DROP TABLE IF EXISTS folio_reporting.instance_languages;
 
---Create a local table for languages in instance records.
+-- Create a local table for languages in instance records.
 CREATE TABLE folio_reporting.instance_languages AS
 SELECT
     instances.id AS instance_id,
     instances.hrid AS instance_hrid,
-    languages.data #>> '{}' AS "language"
+    languages.data #>> '{}' AS "language",
+    languages.ordinality
 FROM
     inventory_instances AS instances
-    CROSS JOIN json_array_elements(json_extract_path(data, 'languages')) AS languages (data);
+    CROSS JOIN LATERAL json_array_elements(json_extract_path(data, 'languages')) WITH ORDINALITY AS languages (data);
 
 CREATE INDEX ON folio_reporting.instance_languages (instance_id);
 

--- a/sql/derived_tables/instance_languages.sql
+++ b/sql/derived_tables/instance_languages.sql
@@ -5,9 +5,10 @@ CREATE TABLE folio_reporting.instance_languages AS
 SELECT
     instances.id AS instance_id,
     instances.hrid AS instance_hrid,
-    json_array_elements_text(json_extract_path(instances.data, 'languages')) AS "language"
+    languages.data #>> '{}' AS "language"
 FROM
-    inventory_instances AS instances;
+    inventory_instances AS instances
+    CROSS JOIN json_array_elements(json_extract_path(data, 'languages')) AS languages (data);
 
 CREATE INDEX ON folio_reporting.instance_languages (instance_id);
 

--- a/sql/report_queries/title_count/title_count.sql
+++ b/sql/report_queries/title_count/title_count.sql
@@ -68,7 +68,7 @@ SELECT
     inform.format_id AS instance_format_id,
     inform.format_code AS instance_format_code,
     inform.format_name AS instance_format_name,
-    (SELECT "language" FROM folio_reporting.instance_languages AS lng WHERE lng.instance_id = inst.instance_id LIMIT 1) AS first_language,
+    lng.language AS first_language,
     insc.statistical_code_id AS instance_statistical_code_id,
     insc.statistical_code AS instance_statistical_code,
     insc.statistical_code_name AS instance_statistical_code_name,
@@ -95,13 +95,12 @@ FROM
     LEFT JOIN folio_reporting.instance_statistical_codes AS insc ON inst.instance_id = insc.instance_id
     LEFT JOIN folio_reporting.instance_nature_content AS innc ON inst.instance_id = innc.instance_id
     LEFT JOIN folio_reporting.instance_formats AS inform ON inst.instance_id = inform.instance_id
-    LEFT JOIN folio_reporting.instance_languages AS inlang ON inst.instance_id = inlang.instance_id
     LEFT JOIN folio_reporting.instance_relationships_ext AS super_relation ON super_relation.relationship_super_instance_id = inst.instance_id
     LEFT JOIN folio_reporting.instance_relationships_ext AS sub_relation ON sub_relation.relationship_sub_instance_id = inst.instance_id
     LEFT JOIN folio_reporting.holdings_ext AS hld ON inst.instance_id = hld.instance_id
     LEFT JOIN folio_reporting.holdings_statistical_codes AS hsc ON hld.holdings_id = hsc.holdings_id
     LEFT JOIN folio_reporting.locations_libraries AS loc ON hld.permanent_location_id = loc.location_id  
-    LEFT JOIN folio_reporting.instance_languages AS lng ON lng.instance_id = inst.instance_id
+    LEFT JOIN folio_reporting.instance_languages AS lng ON lng.instance_id = inst.instance_id AND lng.ordinality = 1
 WHERE 
 
 	-- hardcoded filters 

--- a/sql/report_queries/title_count/title_count.sql
+++ b/sql/report_queries/title_count/title_count.sql
@@ -101,6 +101,7 @@ FROM
     LEFT JOIN folio_reporting.holdings_ext AS hld ON inst.instance_id = hld.instance_id
     LEFT JOIN folio_reporting.holdings_statistical_codes AS hsc ON hld.holdings_id = hsc.holdings_id
     LEFT JOIN folio_reporting.locations_libraries AS loc ON hld.permanent_location_id = loc.location_id  
+    LEFT JOIN folio_reporting.instance_languages AS lng ON lng.instance_id = inst.instance_id
 WHERE 
 
 	-- hardcoded filters 
@@ -160,7 +161,7 @@ WHERE
 			AND (SELECT instance_format_filter3 FROM parameters) = ''))
 	AND	
 	(
-		((SELECT "language" FROM folio_reporting.instance_languages AS lng WHERE lng.instance_id = inst.instance_id LIMIT 1) = (SELECT instance_language_filter FROM parameters))
+		(lng.language = (SELECT instance_language_filter FROM parameters))
 			OR ((SELECT instance_language_filter FROM parameters) = ''))
 	AND 
 	(inst.mode_of_issuance_name = (SELECT instance_mode_of_issuance_filter FROM parameters)


### PR DESCRIPTION
The instance language was selected incorrectly using `LIMIT 1` in a subquery based on the derived table `instance_languages`.  This resulted in random languages being selected rather than the desired "first" language.  In addition, the subquery resulted in extremely long running time.  These commits modify `instance_languages` to include ordinality of the array elements, and modify the title count query to select the instance language where ordinality is `1`.